### PR TITLE
[Breaking] generate a threshold metric for each group

### DIFF
--- a/netprobify/main.py
+++ b/netprobify/main.py
@@ -480,15 +480,17 @@ class NetProbify:
                     self.clear_metrics([THRESHOLD], "destination", [target.name])
 
                     for threshold_name in target.threshold:
-                        threshold = target.threshold[threshold_name]
-                        THRESHOLD.labels(
-                            probe_name=self.global_vars["probe_name"],
-                            destination=target.name,
-                            address_family=target.address_family,
-                            state=target.state,
-                            type=threshold_name,
-                            alert_level=target.alert_level,
-                        ).set(threshold)
+                        for group in target.groups:
+                            threshold = target.threshold[threshold_name]
+                            THRESHOLD.labels(
+                                probe_name=self.global_vars["probe_name"],
+                                destination=target.name,
+                                address_family=target.address_family,
+                                state=target.state,
+                                type=threshold_name,
+                                alert_level=target.alert_level,
+                                group=group,
+                            ).set(threshold)
 
                 target.time_to_refresh = time.time() + target.dns_update_interval
             else:

--- a/netprobify/metrics.py
+++ b/netprobify/metrics.py
@@ -119,7 +119,7 @@ IPERF_OUT_OF_ORDER = Gauge(
 THRESHOLD = Gauge(
     "threshold",
     "threshold for alerting systems.",
-    ["probe_name", "destination", "address_family", "type", "state", "alert_level"],
+    ["probe_name", "destination", "address_family", "type", "state", "alert_level", "group"],
 )
 
 # prometheus metrics - app health

--- a/tests/netprobify/test_main.py
+++ b/tests/netprobify/test_main.py
@@ -868,9 +868,10 @@ def test_reload_conf():
         "latency",
         "in production",
         "paging",
+        "group2",
     ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
-    assert (probe_name, "1_full", "ipv4", "loss", "in production", "paging") in netprobify.getter(
+    assert (probe_name, "1_full", "ipv4", "loss", "in production", "paging", "group2") in netprobify.getter(
         "THRESHOLD"
     ).__dict__["_metrics"]
 
@@ -909,6 +910,7 @@ def test_reload_conf():
         "loss",
         "in production",
         "paging",
+        "group2",
     ) not in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
     assert (
@@ -918,9 +920,10 @@ def test_reload_conf():
         "latency",
         "in production",
         "no_alert",
+        "group2",
     ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
-    assert (probe_name, "1_full", "ipv4", "loss", "in production", "no_alert") in netprobify.getter(
+    assert (probe_name, "1_full", "ipv4", "loss", "in production", "no_alert", "group2") in netprobify.getter(
         "THRESHOLD"
     ).__dict__["_metrics"]
 
@@ -978,9 +981,10 @@ def test_reload_conf():
         "latency",
         "in production",
         "no_alert",
+        "group2",
     ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
-    assert (probe_name, "1_full", "ipv4", "loss", "in production", "no_alert") in netprobify.getter(
+    assert (probe_name, "1_full", "ipv4", "loss", "in production", "no_alert", "group2") in netprobify.getter(
         "THRESHOLD"
     ).__dict__["_metrics"]
 
@@ -1027,6 +1031,7 @@ def test_reload_conf():
         "latency",
         "in production",
         "paging",
+        "group2",
     ) not in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
     assert (
@@ -1036,6 +1041,7 @@ def test_reload_conf():
         "loss",
         "in production",
         "paging",
+        "group2",
     ) not in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
     # check metrics are removed for removed group

--- a/tests/netprobify/test_main.py
+++ b/tests/netprobify/test_main.py
@@ -871,9 +871,15 @@ def test_reload_conf():
         "group2",
     ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
-    assert (probe_name, "1_full", "ipv4", "loss", "in production", "paging", "group2") in netprobify.getter(
-        "THRESHOLD"
-    ).__dict__["_metrics"]
+    assert (
+        probe_name,
+        "1_full",
+        "ipv4",
+        "loss",
+        "in production",
+        "paging",
+        "group2",
+    ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
     # reload the configuration with changed target
     netprobify.config_file = "tests/netprobify/config/test_change_config.yaml"
@@ -923,9 +929,15 @@ def test_reload_conf():
         "group2",
     ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
-    assert (probe_name, "1_full", "ipv4", "loss", "in production", "no_alert", "group2") in netprobify.getter(
-        "THRESHOLD"
-    ).__dict__["_metrics"]
+    assert (
+        probe_name,
+        "1_full",
+        "ipv4",
+        "loss",
+        "in production",
+        "no_alert",
+        "group2",
+    ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
     assert (probe_name, "1_full", "ipv4", "in production", "group2") in netprobify.getter(
         "TCP_LOSS_RATIO"
@@ -984,9 +996,15 @@ def test_reload_conf():
         "group2",
     ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
-    assert (probe_name, "1_full", "ipv4", "loss", "in production", "no_alert", "group2") in netprobify.getter(
-        "THRESHOLD"
-    ).__dict__["_metrics"]
+    assert (
+        probe_name,
+        "1_full",
+        "ipv4",
+        "loss",
+        "in production",
+        "no_alert",
+        "group2",
+    ) in netprobify.getter("THRESHOLD").__dict__["_metrics"]
 
     # reload the configuration with deleted targets/groups
     netprobify.config_file = "tests/netprobify/config/test_deletion_config.yaml"


### PR DESCRIPTION
* a threshold prom metric will be generated for each group the target
  has subscribed
* rationale behind this is to simplify prometheus alert rules as we need
  to join the loss/latency metric to the corresponding threshold, which
  could cause many-to-one conflicts.