### PR TITLE
add setuptools to requirements

### DIFF
--- a/requirements/netprobify.txt
+++ b/requirements/netprobify.txt
@@ -6,6 +6,7 @@ prometheus_client
 pykwalify
 PyYAML
 requests==2.25.1
+setuptools==58.1.0
 scapy==2.4.5
 tornado
 waitress


### PR DESCRIPTION
This is needed to build the PEX or it will raise an error at runtime
  as it can't import pkg_resources lib.