### PR TITLE
chore: rollback to scapy 2.5.0

### DIFF
--- a/requirements/netprobify.in
+++ b/requirements/netprobify.in
@@ -6,6 +6,6 @@ pykwalify
 PyYAML
 requests
 setuptools
-scapy==2.6.0
+scapy==2.5.0
 tornado
 waitress

--- a/requirements/netprobify.txt
+++ b/requirements/netprobify.txt
@@ -50,7 +50,7 @@ ruamel-yaml==0.18.6
     # via pykwalify
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-scapy==2.6.0
+scapy==2.5.0
     # via -r requirements/netprobify.in
 setuptools==75.1.0
     # via -r requirements/netprobify.in


### PR DESCRIPTION
Needs work because of iface change.
https://scapy.readthedocs.io/en/latest/usage.html#multicast